### PR TITLE
Add the version to pre-5 migrations

### DIFF
--- a/db/migrate/20151102045142_add_users.rb
+++ b/db/migrate/20151102045142_add_users.rb
@@ -1,4 +1,4 @@
-class AddUsers < ActiveRecord::Migration
+class AddUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :email

--- a/db/migrate/20151102051542_add_clearance_to_users.rb
+++ b/db/migrate/20151102051542_add_clearance_to_users.rb
@@ -1,4 +1,4 @@
-class AddClearanceToUsers < ActiveRecord::Migration
+class AddClearanceToUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_table :users do |t|
       t.string :encrypted_password, limit: 128

--- a/db/migrate/20151102234652_add_charts.rb
+++ b/db/migrate/20151102234652_add_charts.rb
@@ -1,4 +1,4 @@
-class AddCharts < ActiveRecord::Migration
+class AddCharts < ActiveRecord::Migration[4.2]
   def change
     create_table :charts do |t|
       t.integer :user_id

--- a/db/migrate/20151103005044_add_items.rb
+++ b/db/migrate/20151103005044_add_items.rb
@@ -1,4 +1,4 @@
-class AddItems < ActiveRecord::Migration
+class AddItems < ActiveRecord::Migration[4.2]
   def change
     create_table :items do |t|
       t.string :name

--- a/db/migrate/20151104043020_add_submissions.rb
+++ b/db/migrate/20151104043020_add_submissions.rb
@@ -1,4 +1,4 @@
-class AddSubmissions < ActiveRecord::Migration
+class AddSubmissions < ActiveRecord::Migration[4.2]
   def change
     create_table :submissions do |t|
       t.integer :score

--- a/db/migrate/20151107160832_add_data_to_submissions.rb
+++ b/db/migrate/20151107160832_add_data_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddDataToSubmissions < ActiveRecord::Migration
+class AddDataToSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :submissions, :data, :json
   end

--- a/db/migrate/20151107162752_add_chart_id_to_submissions.rb
+++ b/db/migrate/20151107162752_add_chart_id_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddChartIdToSubmissions < ActiveRecord::Migration
+class AddChartIdToSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_column :submissions, :chart_id, :integer
   end

--- a/db/migrate/20151107170958_add_date_to_submissions.rb
+++ b/db/migrate/20151107170958_add_date_to_submissions.rb
@@ -1,4 +1,4 @@
-class AddDateToSubmissions < ActiveRecord::Migration
+class AddDateToSubmissions < ActiveRecord::Migration[4.2]
   def change
     add_timestamps :submissions
   end

--- a/db/migrate/20151115162439_change_submission_timestamps_to_date.rb
+++ b/db/migrate/20151115162439_change_submission_timestamps_to_date.rb
@@ -1,4 +1,4 @@
-class ChangeSubmissionTimestampsToDate < ActiveRecord::Migration
+class ChangeSubmissionTimestampsToDate < ActiveRecord::Migration[4.2]
   def change
     change_table :submissions do |t|
       t.remove_timestamps


### PR DESCRIPTION
Pre-version 5 Rails migrations simply inherited from `ActiveRecord::Migration`. Since changes in 5 were incompatible, we need to distinguish what version was used for each migration. This adds versions to all the pre-Rails 5 upgrade migrations.